### PR TITLE
Singleuser dockerfile for use with JupyterHub

### DIFF
--- a/docs/development/docker/base/Dockerfile
+++ b/docs/development/docker/base/Dockerfile
@@ -33,12 +33,17 @@ RUN apt-get update -qq && \
         gdb-minimal && \
         python2.7-dbg && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/*  && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install python dependencies. Note we pin ipython to 5.5.0 to get py2.7
+# compatibility.
+RUN pip install --upgrade pip && \
     pip install \
         packaging \
         appdirs \
         numpy \
-        jupyter \
+        ipython==5.5.0 \
+        notebook \
         plotly \
         mpi4py \
         matplotlib \
@@ -52,22 +57,18 @@ RUN apt-get update -qq && \
         sphinxcontrib-napoleon \
         mock \
         scipy && \
-    pip install 'ipython==4.2.0' --force-reinstall && \
     pip install six --upgrade
 
 # ^^^ Note we choose an older version of ipython because it's tooltips work better.
 #     Also, the system six is too old, so we upgrade for the pip version
-
-
-# Install Tini.. this is required because CMD (below) doesn't play nice with notebooks for some reason: https://github.com/ipython/ipython/issues/7062, https://github.com/jupyter/notebook/issues/334
-RUN curl -L https://github.com/krallin/tini/releases/download/v0.6.0/tini > tini && \
-    echo "d5ed732199c36a1189320e6c4859f0169e950692f451c03e7854243b95f4234b *tini" | sha256sum -c - && \
+RUN curl -L https://github.com/krallin/tini/releases/download/v0.10.0/tini > tini && \
+    echo "1361527f39190a7338a0b434bd8c88ff7233ce7b9a4876f3315c22fce7eca1b0 *tini" | sha256sum -c - && \
     mv tini /usr/local/bin/tini && \
     chmod +x /usr/local/bin/tini
 
-# script for xvfb-run.  all docker commands will effectively run under this via the entrypoint
-RUN printf "#\041/bin/sh \n rm -f /tmp/.X99-lock && xvfb-run -s '-screen 0 1600x1200x16' \$@" >> /usr/local/bin/xvfbrun.sh && \
-    chmod +x /usr/local/bin/xvfbrun.sh
+# environment variable will internally run xvfb when glucifer is imported,
+#see /opt/underworld2/glucifer/__init__.py
+ENV GLUCIFER_USE_XVFB 1
 
 # Add a notebook profile.
 RUN mkdir -p -m 700 /root/.jupyter/ && \
@@ -87,5 +88,5 @@ EXPOSE 8888
 
 
 # note we also use xvfb which is required for viz
-ENTRYPOINT ["/usr/local/bin/tini", "--", "xvfbrun.sh"]
+ENTRYPOINT ["/usr/local/bin/tini", "--"]
 

--- a/docs/development/docker/base/Dockerfile
+++ b/docs/development/docker/base/Dockerfile
@@ -29,8 +29,8 @@ RUN apt-get update -qq && \
         less \
         xauth \
         python-tk \
-        swig && \
-        gdb-minimal && \
+        swig \
+        gdb-minimal \
         python2.7-dbg && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/docs/development/docker/underworld2/Dockerfile
+++ b/docs/development/docker/underworld2/Dockerfile
@@ -1,10 +1,10 @@
 FROM underworldcode/underworld2_untested:latest
 MAINTAINER https://github.com/underworldcode/
 
-# set working directory to /root
-WORKDIR /root/underworld2/utils
+# set working directory to /opt
+WORKDIR /opt/underworld2/utils
 
 # run tests
-RUN xvfbrun.sh ./run_tests.py ../docs/examples/1_*.ipynb ../docs/user_guide/*.ipynb ../docs/test/*
+RUN ./run_tests.py ../docs/examples/1_*.ipynb ../docs/user_guide/*.ipynb ../docs/test/*
 
 WORKDIR /workspace

--- a/docs/development/docker/underworld2/Dockerfile
+++ b/docs/development/docker/underworld2/Dockerfile
@@ -2,7 +2,7 @@ FROM underworldcode/underworld2_untested:latest
 MAINTAINER https://github.com/underworldcode/
 
 # set working directory to /opt
-WORKDIR /opt/underworld2/utils
+WORKDIR $UW2_DIR/utils
 
 # run tests
 RUN ./run_tests.py ../docs/examples/1_*.ipynb ../docs/user_guide/*.ipynb ../docs/test/*

--- a/docs/development/docker/underworld2_singleuser/Dockerfile
+++ b/docs/development/docker/underworld2_singleuser/Dockerfile
@@ -61,12 +61,44 @@ RUN rsync -au "$HOME"/.ipython "$HOME"/.jupyter /workspace/
 ENTRYPOINT ["/usr/local/bin/tini", "--", "underworld-entrypoint.sh"]
 CMD ["start-notebook.sh"]
 
-# Add local files as late as possible to avoid cache busting
+# Add local files as late as possible to avoid cache busting. These are the
+# jupyter(hub) startup scripts and config file.
 COPY start.sh /usr/local/bin/
 COPY start-notebook.sh /usr/local/bin/
 COPY start-singleuser.sh /usr/local/bin/
 COPY underworld-entrypoint.sh /usr/local/bin/
 COPY jupyter_notebook_config.py /etc/jupyter/
 RUN chown -R $NB_USER:users /etc/jupyter/
+
+# Include a default landing page for the notebook. See the DEFAULT_LANDING
+# environment variable below for how to enable this option.
+COPY index.html /workspace
+
+# Set the DEFAULT_LANDING environment variable to the notebook URL we want as
+# the landing page a user will see when they first open their server. We can use
+# any notebook URL minus the host and '/user/<username>' parts.
+#
+# Setting the environment variable here hard codes the default value in any
+# image you build. You can override it in a derived Dockerfile, or by passing
+# the desired value to a container at runtime.
+
+# Use '/tree' to replicate the built-in behaviour of the notebook - the
+# directory browser starting in the user's home directory.
+ENV DEFAULT_LANDING /tree
+
+# Start in a specific directory deeper in the user's home directory.
+#ENV DEFAULT_LANDING /tree/tutorials/ConvectionTutorial/Notebooks
+
+# Use the index.html we copied above as the landing page.
+#ENV DEFAULT_LANDING /files/index.html
+
+# Jump directly to a specific notebook.
+#ENV DEFAULT_LANDING /notebooks/examples/1_01_Steady_State_Heat.ipynb
+
+# Open a file in the corresponding notebook viewer
+#ENV DEFAULT_LANDING /view/<filename>
+
+# Open a file in the notebook editor
+#ENV DEFAULT_LANDING /edit/install_guides/nci_raijin.sh
 
 USER $NB_USER

--- a/docs/development/docker/underworld2_singleuser/Dockerfile
+++ b/docs/development/docker/underworld2_singleuser/Dockerfile
@@ -29,7 +29,8 @@ RUN apt-get update -qq && \
         python3-dev
 RUN pip3 install \
         'jupyterhub==0.7.2' \
-        jupyterlab
+        jupyterlab \
+        ipyparallel
 RUN npm install -g configurable-http-proxy
 
 # Install Python 2 kernel spec globally to avoid permission problems when NB_UID
@@ -37,14 +38,6 @@ RUN npm install -g configurable-http-proxy
 # environment to find it. Also, activate the python2 environment upon kernel
 # launch.
 RUN python -m ipykernel install
-
-# Add local files as late as possible to avoid cache busting
-COPY start.sh /usr/local/bin/
-COPY start-notebook.sh /usr/local/bin/
-COPY start-singleuser.sh /usr/local/bin/
-COPY underworld-entrypoint.sh /usr/local/bin/
-COPY jupyter_notebook_config.py /etc/jupyter/
-RUN chown -R $NB_USER:users /etc/jupyter/
 
 # Setup ipyparallel for mpi profile for the NBUSER?
 USER $NB_USER
@@ -55,8 +48,24 @@ RUN ipython2 profile create --parallel --profile=mpi && \
 # Trust underworld notebooks
 RUN find /workspace -name \*.ipynb  -print0 | xargs -0 jupyter trust
 
+USER root
+
+# Copy contents of home directory into /workspace so it'll be copied into the
+# user's persistent home directory the first time they start their server.
+RUN rsync -au "$HOME"/.ipython "$HOME"/.jupyter /workspace/
+
 # Reinstate the xvfb entrypoint, required for underworld viz, and use the
 # customised start command to set up the underworld notebooks in the jupyterhub
 # environment.
 ENTRYPOINT ["/usr/local/bin/tini", "--", "underworld-entrypoint.sh"]
 CMD ["start-notebook.sh"]
+
+# Add local files as late as possible to avoid cache busting
+COPY start.sh /usr/local/bin/
+COPY start-notebook.sh /usr/local/bin/
+COPY start-singleuser.sh /usr/local/bin/
+COPY underworld-entrypoint.sh /usr/local/bin/
+COPY jupyter_notebook_config.py /etc/jupyter/
+RUN chown -R $NB_USER:users /etc/jupyter/
+
+USER $NB_USER

--- a/docs/development/docker/underworld2_singleuser/Dockerfile
+++ b/docs/development/docker/underworld2_singleuser/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update -qq && \
         python3-pip \
         python3-dev
 RUN pip3 install \
-        'jupyterhub==0.7.2' \
+        'jupyterhub==0.8.1' \
         jupyterlab \
         ipyparallel
 RUN npm install -g configurable-http-proxy

--- a/docs/development/docker/underworld2_singleuser/Dockerfile
+++ b/docs/development/docker/underworld2_singleuser/Dockerfile
@@ -1,4 +1,5 @@
-FROM underworldcode/underworld2:latest
+FROM lmoresi/uw2-jupyter-hub-tested:latest
+#FROM underworldcode/underworld2:latest
 MAINTAINER MAINTAINER https://github.com/underworldcode/
 
 # Configure environment for singleuser
@@ -84,13 +85,13 @@ COPY index.html /workspace
 
 # Use '/tree' to replicate the built-in behaviour of the notebook - the
 # directory browser starting in the user's home directory.
-ENV DEFAULT_LANDING /tree
+#ENV DEFAULT_LANDING /tree
 
 # Start in a specific directory deeper in the user's home directory.
 #ENV DEFAULT_LANDING /tree/tutorials/ConvectionTutorial/Notebooks
 
 # Use the index.html we copied above as the landing page.
-#ENV DEFAULT_LANDING /files/index.html
+ENV DEFAULT_LANDING /files/index.html
 
 # Jump directly to a specific notebook.
 #ENV DEFAULT_LANDING /notebooks/examples/1_01_Steady_State_Heat.ipynb

--- a/docs/development/docker/underworld2_singleuser/Dockerfile
+++ b/docs/development/docker/underworld2_singleuser/Dockerfile
@@ -1,0 +1,62 @@
+FROM underworldcode/underworld2:latest
+
+# Configure environment for singleuser
+ENV SHELL /bin/bash
+ENV NB_USER jovyan
+ENV NB_UID 1000
+ENV HOME /home/$NB_USER
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+# Create jovyan user with UID=1000 and in the 'users' group
+RUN useradd -m -s /bin/bash -N -u $NB_UID $NB_USER
+
+USER $NB_USER
+
+# Setup work directory for backward-compatibility
+RUN mkdir /home/$NB_USER/work
+
+USER root
+
+# Install jupyterhub dependencies, including python3
+RUN apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
+        npm \
+        nodejs-legacy \
+        python3 \
+        python3-pip \
+        python3-dev
+RUN pip3 install \
+        jupyterhub \
+        jupyterlab
+RUN npm install -g configurable-http-proxy
+
+# Install Python 2 kernel spec globally to avoid permission problems when NB_UID
+# switching at runtime and to allow the notebook server running out of the root
+# environment to find it. Also, activate the python2 environment upon kernel
+# launch.
+RUN python -m ipykernel install
+
+# Add local files as late as possible to avoid cache busting
+COPY start.sh /usr/local/bin/
+COPY start-notebook.sh /usr/local/bin/
+COPY start-singleuser.sh /usr/local/bin/
+COPY underworld-entrypoint.sh /usr/local/bin/
+COPY jupyter_notebook_config.py /etc/jupyter/
+RUN chown -R $NB_USER:users /etc/jupyter/
+
+# Setup ipyparallel for mpi profile for the NBUSER?
+USER $NB_USER
+WORKDIR $HOME
+RUN ipython2 profile create --parallel --profile=mpi && \
+    echo "c.IPClusterEngines.engine_launcher_class = 'MPIEngineSetLauncher'" >> $HOME/.ipython/profile_mpi/ipcluster_config.py
+
+# Trust underworld notebooks
+RUN find /workspace -name \*.ipynb  -print0 | xargs -0 jupyter trust
+
+# Reinstate the xvfb entrypoint, required for underworld viz, and use the
+# customised start command to set up the underworld notebooks in the jupyterhub
+# environment.
+ENTRYPOINT ["/usr/local/bin/tini", "--", "underworld-entrypoint.sh"]
+CMD ["start-notebook.sh"]

--- a/docs/development/docker/underworld2_singleuser/Dockerfile
+++ b/docs/development/docker/underworld2_singleuser/Dockerfile
@@ -1,4 +1,5 @@
 FROM underworldcode/underworld2:latest
+MAINTAINER MAINTAINER https://github.com/underworldcode/
 
 # Configure environment for singleuser
 ENV SHELL /bin/bash

--- a/docs/development/docker/underworld2_singleuser/Dockerfile
+++ b/docs/development/docker/underworld2_singleuser/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update -qq && \
         python3-pip \
         python3-dev
 RUN pip3 install \
-        jupyterhub \
+        'jupyterhub==0.7.2' \
         jupyterlab
 RUN npm install -g configurable-http-proxy
 

--- a/docs/development/docker/underworld2_singleuser/index.html
+++ b/docs/development/docker/underworld2_singleuser/index.html
@@ -1,0 +1,44 @@
+<html>
+  <body>
+    <h1>Underworld Notebook Landing Page</h1>
+    <p>You can use links on this page to navigate directly to specific example notebooks, static files hosted on your server, or to external links.</p>
+    <h3>Directory browser</h3>
+    Jump directly to the <a href="../tree">directory browser</a>, which is the default landing page for the notebook if not overridden.
+    <h3>Example notebooks</h3>
+    <ul>
+      <li><a href="../notebooks/examples/1_01_Steady_State_Heat.ipynb">Steady State Heat</a></li>
+      <li><a href="../notebooks/examples/1_02_Convection_Example.ipynb">Convection Example</a></li>
+      <li><a href="../notebooks/examples/1_03_BlankenbachBenchmark.ipynb">BlankenbachBenchmark</a></li>
+      <li><a href="../notebooks/examples/1_04_BlankenbachBenchmark_Case2a.ipynb">BlankenbachBenchmark_Case2a</a></li>
+      <li><a href="../notebooks/examples/1_05_StokesSinker.ipynb">StokesSinker</a></li>
+      <li><a href="../notebooks/examples/1_06_Rayleigh_Taylor.ipynb">Rayleigh_Taylor</a></li>
+      <li><a href="../notebooks/examples/1_07_SlabSubduction.ipynb">SlabSubduction</a></li>
+      <li><a href="../notebooks/examples/1_12_Internally_Heated_Convection.ipynb">Internally_Heated_Convection</a></li>
+      <li><a href="../notebooks/examples/1_13_Groundwater_Flow.ipynb">Groundwater_Flow</a></li>
+      <li><a href="../notebooks/examples/1_14_ScalingExample.ipynb">ScalingExample</a></li>
+      <li><a href="../notebooks/examples/1_15_Rayleigh_Taylor_GrowthRate.ipynb">Rayleigh_Taylor_GrowthRate</a></li>
+      <li><a href="../notebooks/examples/1_16_Groundwater_Topography.ipynb">Groundwater_Topography</a></li>
+      <li><a href="../notebooks/examples/1_17_Groundwater_Flow_Temperature_Advection.ipynb">Groundwater_Flow_Temperature_Advection</a></li>
+      <li><a href="../notebooks/examples/1_18_ThermochemicalConvection.ipynb">ThermochemicalConvection</a></li>
+      <li><a href="../notebooks/examples/2_08_ShearBandsSimpleShear.ipynb">ShearBandsSimpleShear</a></li>
+      <li><a href="../notebooks/examples/2_09_ShearBandsPureShear.ipynb">ShearBandsPureShear</a></li>
+      <li><a href="../notebooks/examples/2_11_ViscoelasticityInSimpleShear.ipynb">ViscoelasticityInSimpleShear</a></li>
+      <li><a href="../notebooks/examples/2_16_BasinModellingFramework_Half_Graben.ipynb">BasinModellingFramework_Half_Graben</a></li>
+    </ul>
+    <h3>Tutorial directories</h3>
+    <ul>
+      <li><a href="../tree/tutorials/ConvectionTutorial/Notebooks">Convection Tutorial</a></li>
+      <li><a href="../tree/tutorials/ViscoelasticTutorial">Viscoelastic Tutorial</a></li>
+    </ul>
+    <h3>Static content</h3>
+    <ul>
+      <li>View the <a href="api_doc/index.html">API documentation</a></li>
+      <li>View the <a href="cheatsheet/cheatsheet.pdf">cheatsheet PDF file</a></li>
+      <li>Edit a <a href="../edit/install_guides/nci_raijin.sh">shell script</a></li>
+    </ul>
+    <h3>External content</h3>
+    <ul>
+      <li><a href="https://github.com/underworldcode/underworld2">Underworld on GitHub</a></li>
+    </ul>
+  </body>
+</html>

--- a/docs/development/docker/underworld2_singleuser/jupyter_notebook_config.py
+++ b/docs/development/docker/underworld2_singleuser/jupyter_notebook_config.py
@@ -1,0 +1,36 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from jupyter_core.paths import jupyter_data_dir
+import subprocess
+import os
+import errno
+import stat
+
+c = get_config()
+c.NotebookApp.ip = '*'
+c.NotebookApp.port = 8888
+c.NotebookApp.open_browser = False
+
+# Generate a self-signed certificate
+if 'GEN_CERT' in os.environ:
+    dir_name = jupyter_data_dir()
+    pem_file = os.path.join(dir_name, 'notebook.pem')
+    try:
+        os.makedirs(dir_name)
+    except OSError as exc:  # Python >2.5
+        if exc.errno == errno.EEXIST and os.path.isdir(dir_name):
+            pass
+        else:
+            raise
+    # Generate a certificate if one doesn't exist on disk
+    subprocess.check_call(['openssl', 'req', '-new',
+                           '-newkey', 'rsa:2048',
+                           '-days', '365',
+                           '-nodes', '-x509',
+                           '-subj', '/C=XX/ST=XX/L=XX/O=generated/CN=generated',
+                           '-keyout', pem_file,
+                           '-out', pem_file])
+    # Restrict access to the file
+    os.chmod(pem_file, stat.S_IRUSR | stat.S_IWUSR)
+    c.NotebookApp.certfile = pem_file

--- a/docs/development/docker/underworld2_singleuser/jupyter_notebook_config.py
+++ b/docs/development/docker/underworld2_singleuser/jupyter_notebook_config.py
@@ -14,7 +14,6 @@ import stat
 c = get_config()
 c.NotebookApp.ip = '*'
 c.NotebookApp.port = 8888
-c.NotebookApp.open_browser = False
 
 # Generate a self-signed certificate
 if 'GEN_CERT' in os.environ:
@@ -42,3 +41,5 @@ if 'GEN_CERT' in os.environ:
 # Start with a default landing page if 'DEFAULT_LANDING' is set.
 if 'DEFAULT_LANDING' in os.environ:
     c.NotebookApp.default_url = os.environ.get('DEFAULT_LANDING')
+
+c.NotebookApp.allow_origin = '*'

--- a/docs/development/docker/underworld2_singleuser/jupyter_notebook_config.py
+++ b/docs/development/docker/underworld2_singleuser/jupyter_notebook_config.py
@@ -1,5 +1,9 @@
-# Copyright (c) Jupyter Development Team.
+# Copyright (c) CSIRO Data61
 # Distributed under the terms of the Modified BSD License.
+#
+# Derived from
+# https://github.com/jupyter/docker-stacks/blob/master/base-notebook/jupyter_notebook_config.py
+# but adds a default HTML landing page to the notebook.
 
 from jupyter_core.paths import jupyter_data_dir
 import subprocess
@@ -34,3 +38,7 @@ if 'GEN_CERT' in os.environ:
     # Restrict access to the file
     os.chmod(pem_file, stat.S_IRUSR | stat.S_IWUSR)
     c.NotebookApp.certfile = pem_file
+
+# Start with a default landing page if 'DEFAULT_LANDING' is set.
+if 'DEFAULT_LANDING' in os.environ:
+    c.NotebookApp.default_url = os.environ.get('DEFAULT_LANDING')

--- a/docs/development/docker/underworld2_singleuser/start-notebook.sh
+++ b/docs/development/docker/underworld2_singleuser/start-notebook.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+set -e
+
+if [[ ! -z "${JUPYTERHUB_API_TOKEN}" ]]; then
+  # launched by JupyterHub, use single-user entrypoint
+  exec /usr/local/bin/start-singleuser.sh $*
+else
+  . /usr/local/bin/start.sh jupyter notebook $*
+fi

--- a/docs/development/docker/underworld2_singleuser/start-singleuser.sh
+++ b/docs/development/docker/underworld2_singleuser/start-singleuser.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+set -e
+
+notebook_arg=""
+if [ -n "${NOTEBOOK_DIR:+x}" ]
+then
+    notebook_arg="--notebook-dir=${NOTEBOOK_DIR}"
+fi
+
+. /usr/local/bin/start.sh jupyterhub-singleuser \
+  --port=${JPY_PORT:-8888} \
+  --ip=0.0.0.0 \
+  --user=$JPY_USER \
+  --cookie-name=$JPY_COOKIE_NAME \
+  --base-url=$JPY_BASE_URL \
+  --hub-prefix=$JPY_HUB_PREFIX \
+  --hub-api-url=$JPY_HUB_API_URL \
+  ${notebook_arg} \
+  $@

--- a/docs/development/docker/underworld2_singleuser/start.sh
+++ b/docs/development/docker/underworld2_singleuser/start.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+set -e
+
+# Handle special flags if we're root
+if [ $(id -u) == 0 ] ; then
+    # Change UID of NB_USER to NB_UID if it does not match
+    if [ "$NB_UID" != $(id -u $NB_USER) ] ; then
+        echo "Set user UID to: $NB_UID"
+        usermod -u $NB_UID $NB_USER
+        # Careful: $HOME might resolve to /root depending on how the
+        # container is started. Use the $NB_USER home path explicitly.
+        for d in "$CONDA_DIR" "$JULIA_PKGDIR" "/home/$NB_USER"; do
+            if [[ ! -z "$d" && -d "$d" ]]; then
+                echo "Set ownership to uid $NB_UID: $d"
+                chown -R $NB_UID "$d"
+            fi
+        done
+    fi
+
+    # Change GID of NB_USER to NB_GID if NB_GID is passed as a parameter
+    if [ "$NB_GID" ] ; then
+        echo "Change GID to $NB_GID"
+        groupmod -g $NB_GID -o $(id -g -n $NB_USER)
+    fi
+
+    # Enable sudo if requested
+    if [ ! -z "$GRANT_SUDO" ]; then
+        echo "$NB_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/notebook
+    fi
+
+    # Exec the command as NB_USER
+    echo "Execute the command as $NB_USER"
+    exec su $NB_USER -c "env PATH=$PATH $*"
+else
+    # Exec the command
+    echo "Execute the command"
+    exec $*
+fi

--- a/docs/development/docker/underworld2_singleuser/underworld-entrypoint.sh
+++ b/docs/development/docker/underworld2_singleuser/underworld-entrypoint.sh
@@ -17,7 +17,7 @@ then
         # Copy underworld notebooks into user's workspace, making sure not to
         # overwrite any existing copies which the user may have modified and saved
         # on a previous run.
-        cp -a --no-clobber /workspace/* "${NOTEBOOK_DIR}"
+        rsync -au /workspace/ "${NOTEBOOK_DIR}/"
 
     else
         echo Unable to copy notebooks from workspace

--- a/docs/development/docker/underworld2_singleuser/underworld-entrypoint.sh
+++ b/docs/development/docker/underworld2_singleuser/underworld-entrypoint.sh
@@ -19,6 +19,12 @@ then
         # on a previous run.
         rsync -au /workspace/.ipython /workspace/.jupyter /workspace/* "${NOTEBOOK_DIR}/"
 
+        # Fix links in static html files to account for the jupyterhub proxy
+        # serving content on a prefix path.
+        ( shopt -s globstar dotglob
+          sed -i -- "s/\\(href\\|src\\)=\"\\/\\(tree\\|files\\|terminals\\|edit\\)\\([^\"]*\\)\"/\\1=\"${JUPYTERHUB_SERVICE_PREFIX//\//\\\/}\\2\\3\"/g" "${NOTEBOOK_DIR}"/**/*.html
+        )
+
     else
         echo Unable to copy notebooks from workspace
         echo "${NOTEBOOK_DIR}" is not a directory!

--- a/docs/development/docker/underworld2_singleuser/underworld-entrypoint.sh
+++ b/docs/development/docker/underworld2_singleuser/underworld-entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Copyright (c) CSIRO Data61
+# Distributed under the terms of the Modified BSD License.
+
+set -e
+
+# If we're being launched by jupyterhub then initialise the user's environment
+if [[ ! -z "${JUPYTERHUB_API_TOKEN}" ]]
+then
+    # Use the $NB_USER's home workspace by default, unless a notebook directory
+    # was passed.
+    : ${NOTEBOOK_DIR:=/home/$NB_USER}
+
+    # Make sure the notebook dir exists and is a directory.
+    if [ -d "${NOTEBOOK_DIR}" ]; then
+
+        # Copy underworld notebooks into user's workspace, making sure not to
+        # overwrite any existing copies which the user may have modified and saved
+        # on a previous run.
+        cp -a --no-clobber /workspace/* "${NOTEBOOK_DIR}"
+
+    else
+        echo Unable to copy notebooks from workspace
+        echo "${NOTEBOOK_DIR}" is not a directory!
+    fi
+fi
+
+# No longer required, since glucifer can invoke xvfb directly
+# # Wrap the provided command with xvfb-run so we can do viz
+# rm -f /tmp/.X99-lock && xvfb-run -s '-screen 0 1600x1200x16' $@
+
+$@

--- a/docs/development/docker/underworld2_singleuser/underworld-entrypoint.sh
+++ b/docs/development/docker/underworld2_singleuser/underworld-entrypoint.sh
@@ -17,7 +17,7 @@ then
         # Copy underworld notebooks into user's workspace, making sure not to
         # overwrite any existing copies which the user may have modified and saved
         # on a previous run.
-        rsync -au /workspace/ "${NOTEBOOK_DIR}/"
+        rsync -au /workspace/.ipython /workspace/.jupyter /workspace/* "${NOTEBOOK_DIR}/"
 
     else
         echo Unable to copy notebooks from workspace

--- a/docs/development/docker/underworld2_untested/Dockerfile
+++ b/docs/development/docker/underworld2_untested/Dockerfile
@@ -1,11 +1,11 @@
 FROM underworldcode/base:latest
 MAINTAINER https://github.com/underworldcode/
 
-# set working directory to /root
-WORKDIR /root
+# set working directory to /opt
+WORKDIR /opt
 
 # setup environment
-ENV PYTHONPATH $PYTHONPATH:/root/underworld2
+ENV PYTHONPATH $PYTHONPATH:/opt/underworld2
 
 # get underworld, compile, delete some unnecessary files, trust notebooks, copy to workspace
 RUN git clone --branch "master" --single-branch https://github.com/underworldcode/underworld2 && \
@@ -23,7 +23,7 @@ RUN git clone --branch "master" --single-branch https://github.com/underworldcod
     rm -fr StgDomain             && \
     rm -fr PICellerator          && \
     rm -fr Solvers               && \
-    find /root/underworld2/docs -name \*.ipynb  -print0 | xargs -0 jupyter trust && \
+    find /opt/underworld2/docs -name \*.ipynb  -print0 | xargs -0 jupyter trust && \
     mkdir /workspace                                                 && \
     cd ../../docs/development/api_doc_generator/                     && \
     sphinx-build . ../../api_doc                                     && \

--- a/docs/development/docker/underworld2_untested/Dockerfile
+++ b/docs/development/docker/underworld2_untested/Dockerfile
@@ -1,11 +1,10 @@
 FROM underworldcode/base:latest
 MAINTAINER https://github.com/underworldcode/
 
-# set working directory to /opt
+# set working directory to /opt, and install underworld files there.
 WORKDIR /opt
-
-# setup environment
-ENV PYTHONPATH $PYTHONPATH:/opt/underworld2
+ENV UW2_DIR /opt/underworld2
+ENV PYTHONPATH $PYTHONPATH:$UW2_DIR
 
 # get underworld, compile, delete some unnecessary files, trust notebooks, copy to workspace
 RUN git clone --branch "master" --single-branch https://github.com/underworldcode/underworld2 && \
@@ -23,11 +22,11 @@ RUN git clone --branch "master" --single-branch https://github.com/underworldcod
     rm -fr StgDomain             && \
     rm -fr PICellerator          && \
     rm -fr Solvers               && \
-    find /opt/underworld2/docs -name \*.ipynb  -print0 | xargs -0 jupyter trust && \
+    find $UW2_DIR/docs -name \*.ipynb  -print0 | xargs -0 jupyter trust && \
     mkdir /workspace                                                 && \
     cd ../../docs/development/api_doc_generator/                     && \
     sphinx-build . ../../api_doc                                     && \
-    rsync -av /root/underworld2/docs/. /workspace
+    rsync -av $UW2_DIR/docs/. /workspace
 
 
 # expose notebook port


### PR DESCRIPTION
Adds a Dockerfile plus utilities to build a single user notebook image compatible with JupyterHub. It mostly follows the conventions set up by the Jupyter team's docker-stacks repository (https://github.com/jupyter/docker-stacks), which is also where most of the utility files come from.

I made some tweaks to the base/underworld2_untested/underworld2 Dockerfiles to allow for the singleuser setup:

* Updated dependencies for Jupyter
* Replace xvfbrun wrapper with GLUCIFER_USE_XFVB env var
* Clone and build UW2 in /opt instead of /root to avoid permission issues

If there are scripts that are hard coded to use UW2 in /root, it may be necessary to add a symlink from /root/underworld2 to /opt/underworld2 as a temporary fix.