### PR TITLE
Adding argument 'gauss_swarm' to all fem system objects.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,17 @@
 CHANGES: Underworld2
 =======================
 
+Release 2.11.0 []
+-----------------
+Changes
+* Enabled user defined Gauss integration swarms for all systems. 
+
+New:
+* Added `underworld.function.count()` method, which counts function calls. 
+
+Fixes:
+* Fix bug where multiple solvers added multiple preconditioners. 
+
 Release 2.10.0 []
 ----------------
 Fixes:

--- a/docs/test/test_gauss_swarms.py
+++ b/docs/test/test_gauss_swarms.py
@@ -1,0 +1,54 @@
+import underworld as uw
+res = 4
+mesh = uw.mesh.FeMesh_Cartesian(elementRes=(res,res))
+v = mesh.add_variable(2)
+p = mesh.subMesh.add_variable(1)
+t = mesh.add_variable(1)
+diffusivity = 1.
+counted_diffusivity = uw.function.view.count(diffusivity)
+
+
+for i in range(1,5):
+    counted_diffusivity.reset()
+    gaussSwarm = uw.swarm.GaussIntegrationSwarm(mesh,i)
+    sys = uw.systems.Stokes(v,p, fn_viscosity=counted_diffusivity, fn_bodyforce=(0.,0.),gauss_swarm=gaussSwarm)
+    solver = uw.systems.Solver(sys).solve()
+    count_encountered  = counted_diffusivity.count()
+    count_expected = i*i*res*res*2 # factor of 2 for preconditioner
+    if (count_encountered != count_expected):
+        raise RuntimeError("Function call count ({}) not as expected ({}) for Stokes. Gauss swarm possibly not being used correctly.".format(count_encountered,count_expected))
+
+for i in range(1,5):
+    counted_diffusivity.reset()
+    gaussSwarm = uw.swarm.GaussIntegrationSwarm(mesh,i)
+    sys = uw.systems.SteadyStateHeat(t,counted_diffusivity, gauss_swarm=gaussSwarm)
+    solver = uw.systems.Solver(sys).solve()
+    count_encountered  = counted_diffusivity.count()
+    count_expected = i*i*res*res
+    if (count_encountered != count_expected):
+        raise RuntimeError("Function call count ({}) not as expected ({}) for SteadyStateHeat. Gauss swarm possibly not being used correctly.".format(count_encountered,count_expected))
+
+
+v.data[:] = (1.,1.)
+for i in range(1,5):
+    gaussSwarm = uw.swarm.GaussIntegrationSwarm(mesh,i)
+    sys = uw.systems.AdvectionDiffusion(t,v,counted_diffusivity,phiDotField=t,gauss_swarm=gaussSwarm)
+    dt = sys.get_max_dt()
+    counted_diffusivity.reset()
+    sys.integrate()
+    count_encountered  = counted_diffusivity.count()
+    count_expected = i*i*res*res*4
+    if (count_encountered != count_expected):
+        raise RuntimeError("Function call count ({}) not as expected ({}) for AdvectionDiffusion. Gauss swarm possibly not being used correctly.".format(count_encountered,count_expected))
+
+v.data[:] = (1.,1.)
+for i in range(1,5):
+    gaussSwarm = uw.swarm.GaussIntegrationSwarm(mesh,i)
+    sys = uw.systems.AdvectionDiffusion(t,v,counted_diffusivity,method="SLCN",gauss_swarm=gaussSwarm)
+    dt = sys.get_max_dt()
+    counted_diffusivity.reset()
+    sys.integrate()
+    count_encountered  = counted_diffusivity.count()
+    count_expected = i*i*res*res*2
+    if (count_encountered != count_expected):
+        raise RuntimeError("Function call count ({}) not as expected ({}) for AdvectionDiffusion. Gauss swarm possibly not being used correctly.".format(count_encountered,count_expected))

--- a/underworld/function/view.py
+++ b/underworld/function/view.py
@@ -380,3 +380,74 @@ class min_max(_function.Function):
         """ Resets the minimum and maximum values.
         """
         return self._fncself.reset()
+
+
+class count(_function.Function):
+    """ 
+    This function simply records the number of times a function 
+    has been called.
+    
+    Example
+    -------
+    Create a simple function which returns two times its input:
+    
+    >>> import underworld as uw
+    >>> import underworld.function as fn
+    >>> import numpy as np
+    >>> fn_simple = fn.input()
+    >>> fn_count = fn.view.count(fn_simple)
+    
+    Now do an evaluation:
+    
+    >>> result = fn_count.evaluate(5.)
+    
+    Check count:
+
+    >>> fn_count.count()
+    1
+
+    Do a few more evaluations:
+
+    >>> result = fn_count.evaluate(5.)
+    >>> result = fn_count.evaluate(5.)
+    >>> result = fn_count.evaluate(5.)
+    >>> fn_count.count()
+    4
+
+    Reset and go again
+
+    >>> fn_count.reset()
+    >>> result = fn_count.evaluate(5.)
+    >>> result = fn_count.evaluate(5.)
+    >>> fn_count.count()
+    2
+
+    """
+    def __init__(self, fn):
+
+        _fn = _function.Function.convert(fn)
+        if _fn == None:
+            raise ValueError( "provided 'fn' must a 'Function' or convertible.")
+        self._fn = _fn
+
+        # create c instance
+        self._fncself = _cfn.Count( self._fn._fncself )
+
+        # build parent
+        super(count,self).__init__(argument_fns=[fn,])
+
+    def count(self):
+        """
+        Returns the function call count.
+        
+        Returns
+        -------
+        int: count
+        """
+        return self._fncself.count
+
+    def reset(self):
+        """
+        Resets the count.
+        """
+        return self._fncself.reset()

--- a/underworld/libUnderworld/Solvers/KSPSolvers/src/StokesBlockKSPInterface.c
+++ b/underworld/libUnderworld/Solvers/KSPSolvers/src/StokesBlockKSPInterface.c
@@ -146,7 +146,8 @@ void _StokesBlockKSPInterface_Build( void* solver, void* sle ) {/* it is the sle
 	/* Build Preconditioner */
 	if ( self->preconditioner ) {
 		Stg_Component_Build( self->preconditioner, sle, False );
-		SystemLinearEquations_AddStiffnessMatrix( self->st_sle, self->preconditioner );
+		if(!SystemLinearEquations_GetStiffnessMatrix( self->st_sle, self->preconditioner->name ))  // only add if not already there. 
+			SystemLinearEquations_AddStiffnessMatrix( self->st_sle, self->preconditioner );
 
 	}
 	if( self->mg ){

--- a/underworld/libUnderworld/Underworld/Function/src/Count.hpp
+++ b/underworld/libUnderworld/Underworld/Function/src/Count.hpp
@@ -1,0 +1,47 @@
+/*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*
+**                                                                                  **
+** This file forms part of the Underworld geophysics modelling application.         **
+**                                                                                  **
+** For full license and copyright information, please refer to the LICENSE.md file  **
+** located at the project root, or contact the authors.                             **
+**                                                                                  **
+**~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*/
+
+#ifndef __Underworld_Function_Count_hpp__
+#define __Underworld_Function_Count_hpp__
+
+#include <iostream>
+
+#include "FunctionIO.hpp"
+
+namespace Fn {
+
+    class Count: public Function
+    {
+        public:
+            Count(Function *fn_input):count(0),_fn_input(fn_input){};
+            virtual ~Count(){};
+            int count;
+            virtual func getFunction( IOsptr sample_input )
+            {
+                func func_input = _fn_input->getFunction( sample_input );
+                // Do a decrement as the lambda will be called (to determine
+                // what it itself returns) after this `getFunction` returns. 
+                // I'm not 100% how robust this is. JM.
+                count-=1;
+                return [func_input,this](IOsptr input)->IOsptr 
+                    { 
+                        count+=1; 
+                        return func_input(input); 
+                    };
+            };
+            void reset(){count=0;};
+        protected:
+            Function* _fn_input;
+    };
+        
+}
+
+
+#endif /* __Underworld_Function_Count_hpp__ */
+

--- a/underworld/libUnderworld/libUnderworldPy/Function.i
+++ b/underworld/libUnderworld/libUnderworldPy/Function.i
@@ -31,6 +31,7 @@
 #include <Underworld/Function/SafeMaths.hpp>
 #include <Underworld/Function/CustomException.hpp>
 #include <Underworld/Function/MinMax.hpp>
+#include <Underworld/Function/Count.hpp>
 #include <Underworld/Function/Constant.hpp>
 #include <Underworld/Function/SwarmVariableFn.hpp>
 #include <Underworld/Function/ParticleFound.hpp>
@@ -80,6 +81,7 @@ extern "C" {
 %include "Function/SafeMaths.hpp"
 %include "Function/CustomException.hpp"
 %include "Function/MinMax.hpp"
+%include "Function/Count.hpp"
 %include "Function/Unary.hpp"
 %include "Function/Binary.hpp"
 %include "Function/Constant.hpp"

--- a/underworld/libUnderworld/libUnderworldPy/Underworld.i
+++ b/underworld/libUnderworld/libUnderworldPy/Underworld.i
@@ -30,6 +30,7 @@
 #include <Underworld/Function/SafeMaths.hpp>
 #include <Underworld/Function/CustomException.hpp>
 #include <Underworld/Function/MinMax.hpp>
+#include <Underworld/Function/Count.hpp>
 #include <Underworld/Function/Constant.hpp>
 #include <Underworld/Function/SwarmVariableFn.hpp>
 #include <Underworld/Function/ParticleFound.hpp>

--- a/underworld/systems/_advectiondiffusion.py
+++ b/underworld/systems/_advectiondiffusion.py
@@ -202,7 +202,7 @@ class _SLCN_AdvectionDiffusion(object):
 
         # setup the gauss integration swarm
         if gauss_swarm != None:
-            if type(gauss_swarm) != uw.swarm.GaussIntegrationSwarm:
+            if not isinstance(gauss_swarm,uw.swarm.GaussIntegrationSwarm):
                 raise RuntimeError( "Provided 'gauss_swarm' must be a GaussIntegrationSwarm object" )
             intSwarm = gauss_swarm
         else:
@@ -930,7 +930,7 @@ class _SUPG_AdvectionDiffusion(_stgermain.StgCompoundComponent):
 
         # setup the gauss integration swarm
         if gauss_swarm != None:
-            if type(gauss_swarm) != uw.swarm.GaussIntegrationSwarm:
+            if not isinstance(gauss_swarm,uw.swarm.GaussIntegrationSwarm):
                 raise RuntimeError( "Provided 'gauss_swarm' must be a GaussIntegrationSwarm object" )
             self._gaussSwarm = gauss_swarm
         else:

--- a/underworld/systems/_darcyflow.py
+++ b/underworld/systems/_darcyflow.py
@@ -72,6 +72,12 @@ class SteadyStateDarcyFlow(_stgermain.StgCompoundComponent):
     conditions : underworld.conditions.SystemCondition
         Numerical conditions to impose on the system. This should be supplied as
         the condition itself, or a list object containing the conditions.
+    gauss_swarm : underworld.swarm.GaussIntegrationSwarm
+        If provided this gauss_swarm will be used for (gaussian) numerical 
+        integration rather than a default gauss integration swarm that is 
+        automatically generated and dependent on the element order of the mesh. 
+        NB: if a voronoi_swarm is defined it OVERRIDES this gauss_swarm as the
+        preferred integration swarm (quadrature method).
     velocityField : underworld.mesh.MeshVariable
         Solution field for darcy flow velocity. Optional.
     swarmVarVelocity : undeworld.swarm.SwarmVariable
@@ -88,7 +94,7 @@ class SteadyStateDarcyFlow(_stgermain.StgCompoundComponent):
     _objectsDict = {  "_system" : "SystemLinearEquations" }
     _selfObjectName = "_system"
 
-    def __init__(self, pressureField, fn_diffusivity, fn_bodyforce=None, voronoi_swarm=None, conditions=[], velocityField=None, swarmVarVelocity=None, _removeBCs=True, **kwargs):
+    def __init__(self, pressureField, fn_diffusivity, fn_bodyforce=None, voronoi_swarm=None, conditions=[], velocityField=None, swarmVarVelocity=None, _removeBCs=True, gauss_swarm=None, **kwargs):
 
         if not isinstance( pressureField, uw.mesh.MeshVariable):
             raise TypeError( "Provided 'pressureField' must be of 'MeshVariable' class." )
@@ -152,6 +158,22 @@ class SteadyStateDarcyFlow(_stgermain.StgCompoundComponent):
             else:
                 raise RuntimeError("Can't decide on input condition")
 
+        # setup the gauss integration swarm
+        if gauss_swarm != None:
+            if type(gauss_swarm) != uw.swarm.GaussIntegrationSwarm:
+                raise RuntimeError( "Provided 'gauss_swarm' must be a GaussIntegrationSwarm object" )
+            intswarm = gauss_swarm
+        else:
+            intswarm = uw.swarm.GaussIntegrationSwarm(mesh)
+
+        # we will use voronoi if that has been requested by the user, else use
+        # gauss integration.
+        if self._swarm:
+            intswarm = self._swarm._voronoi_swarm
+            # need to ensure voronoi is populated now, as assembly terms will call
+            # initial test functions which may require a valid voronoi swarm
+            self._swarm._voronoi_swarm.repopulate()
+
         # build the equation numbering for the temperature field discretisation
         tEqNums = self._tEqNums = sle.EqNumber( pressureField, removeBCs=self._removeBCs )
 
@@ -164,18 +186,6 @@ class SteadyStateDarcyFlow(_stgermain.StgCompoundComponent):
 
         # and matrices
         self._kmatrix = sle.AssembledMatrix( self._solutionVector, self._solutionVector, rhs=self._fvector )
-
-
-        # we will use voronoi if that has been requested by the user, else use
-        # gauss integration.
-        if self._swarm:
-            intswarm = self._swarm._voronoi_swarm
-            # need to ensure voronoi is populated now, as assembly terms will call
-            # initial test functions which may require a valid voronoi swarm
-            self._swarm._voronoi_swarm.repopulate()
-        else:
-            intswarm = uw.swarm.GaussIntegrationSwarm(mesh)
-
 
         self._kMatTerm = sle.MatrixAssemblyTerm_NA_i__NB_i__Fn(  integrationSwarm=intswarm,
                                                                  assembledObject=self._kmatrix,

--- a/underworld/systems/_stokes.py
+++ b/underworld/systems/_stokes.py
@@ -201,7 +201,7 @@ class Stokes(_stgermain.StgCompoundComponent):
 
         # setup the gauss integration swarm
         if gauss_swarm != None:
-            if type(gauss_swarm) != uw.swarm.GaussIntegrationSwarm:
+            if not isinstance(gauss_swarm,uw.swarm.GaussIntegrationSwarm):
                 raise RuntimeError( "Provided 'gauss_swarm' must be a GaussIntegrationSwarm object" )
             gaussSwarm = gauss_swarm
         else:

--- a/underworld/systems/_thermal.py
+++ b/underworld/systems/_thermal.py
@@ -154,7 +154,7 @@ class SteadyStateHeat(_stgermain.StgCompoundComponent):
 
         # setup the gauss integration swarm
         if gauss_swarm != None:
-            if type(gauss_swarm) != uw.swarm.GaussIntegrationSwarm:
+            if not isinstance(gauss_swarm,uw.swarm.GaussIntegrationSwarm):
                 raise RuntimeError( "Provided 'gauss_swarm' must be a GaussIntegrationSwarm object" )
             intswarm = gauss_swarm
         else:

--- a/underworld/utils/_meshvariable_projection.py
+++ b/underworld/utils/_meshvariable_projection.py
@@ -204,7 +204,7 @@ class MeshVariable_Projection(_stgermain.StgCompoundComponent):
 
         # setup the gauss integration swarm
         if gauss_swarm != None:
-            if type(gauss_swarm) != uw.swarm.GaussIntegrationSwarm:
+            if not isinstance(gauss_swarm,uw.swarm.GaussIntegrationSwarm):
                 raise RuntimeError( "Provided 'gauss_swarm' must be a GaussIntegrationSwarm object" )
             intswarm = gauss_swarm
         else:

--- a/underworld/utils/_meshvariable_projection.py
+++ b/underworld/utils/_meshvariable_projection.py
@@ -98,6 +98,12 @@ class MeshVariable_Projection(_stgermain.StgCompoundComponent):
         utilised to integrate across elements. The provided swarm is used as the 
         basis for the voronoi integration. If no swarm is provided, Gauss 
         integration is used.
+    gauss_swarm : underworld.swarm.GaussIntegrationSwarm
+        If provided this gauss_swarm will be used for (gaussian) numerical 
+        integration rather than a default gauss integration swarm that is 
+        automatically generated and dependent on the element order of the mesh. 
+        NB: if a voronoi_swarm is defined it OVERRIDES this gauss_swarm as the
+        preferred integration swarm (quadrature method).
     type : int, default=0
         Projection type.  0:`weighted average`, 1:`weighted residual`
 
@@ -161,7 +167,7 @@ class MeshVariable_Projection(_stgermain.StgCompoundComponent):
     _objectsDict = {  "_system" : "SystemLinearEquations" }
     _selfObjectName = "_system"
         
-    def __init__(self, meshVariable=None, fn=None, voronoi_swarm=None, type=0, **kwargs):
+    def __init__(self, meshVariable=None, fn=None, voronoi_swarm=None, type=0, gauss_swarm=None, **kwargs):
 
         if not meshVariable:
             raise ValueError("You must specify a mesh variable via the 'meshVariable' parameter.")
@@ -183,8 +189,6 @@ class MeshVariable_Projection(_stgermain.StgCompoundComponent):
             import warnings
             warnings.warn("Voronoi integration may yield unsatisfactory results for Q2 mesh.")
             
-
-
         if not type in [0,1]:
             raise ValueError( "Provided 'type' must take a value of 0 (weighted average) or 1 (weighted residual)." )
         self.type = type
@@ -198,6 +202,14 @@ class MeshVariable_Projection(_stgermain.StgCompoundComponent):
         if hasattr(self._meshVariable.mesh.generator, 'geometryMesh'):
             geometryMesh = self._meshVariable.mesh.generator.geometryMesh
 
+        # setup the gauss integration swarm
+        if gauss_swarm != None:
+            if type(gauss_swarm) != uw.swarm.GaussIntegrationSwarm:
+                raise RuntimeError( "Provided 'gauss_swarm' must be a GaussIntegrationSwarm object" )
+            intswarm = gauss_swarm
+        else:
+            intswarm = uw.swarm.GaussIntegrationSwarm(geometryMesh)
+
         # we will use voronoi if that has been requested by the user, else use
         # gauss integration.
         if self._swarm:
@@ -205,8 +217,6 @@ class MeshVariable_Projection(_stgermain.StgCompoundComponent):
             # need to ensure voronoi is populated now, as assembly terms will call
             # initial test functions which may require a valid voronoi swarm
             self._swarm._voronoi_swarm.repopulate()
-        else:
-            intswarm = uw.swarm.GaussIntegrationSwarm(geometryMesh)
 
         self._fn = _fn
 


### PR DESCRIPTION
If provided the 'gauss_swarm' will be used for numerical
integration rather than a default gauss integration swarm that is
automatically generated and dependent on the element order of the mesh.

NB: if a voronoi_swarm is defined it OVERRIDES this gauss_swarm as the
preferred integration swarm (quadrature method).