### PR TITLE
Fix for h5py v3 & recent jupyter-nbconvert.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,10 @@ New:
 
 Fixes:
 * Fix bug where multiple solvers added multiple preconditioners. 
+* H5py v3 is more strict in allowed indexing array shapes. Updated our 
+  structures to accomodate. 
+* Tester uses `jupyter-nbconvert` which no longer defaults to Python. Update
+  to explicitly select Python.
 
 Release 2.10.1 [2020-08-28]
 ---------------------------

--- a/docs/development/run_tests.py
+++ b/docs/development/run_tests.py
@@ -178,7 +178,7 @@ if __name__ == '__main__':
         cleanup=False
         # if prefix args found and it's an ipynb, use 'jupyter nbconvert --execute'
         if is_ipynb and not args.prepend:
-            exe = ['jupyter', 'nbconvert', '--ExecutePreprocessor.kernel_name="python3"',
+            exe = ['jupyter', 'nbconvert', '--to=python', '--ExecutePreprocessor.kernel_name="python3"',
                    '--ExecutePreprocessor.timeout=10000','--execute', '--stdout']
         elif is_ipynb and args.prepend:
             # convert ipynb to py and run with python

--- a/docs/test/func_debug_messages.py
+++ b/docs/test/func_debug_messages.py
@@ -27,7 +27,7 @@ if __name__ == '__main__':
                                 "Expected:\n{}\n\n"
                                 "Encountered:\n{}\n\n".format(test,strmessage,strenderr))
         def do_test_jupyter(test,expected_message):
-            command = "jupyter nbconvert --execute {}".format(test)
+            command = "jupyter nbconvert --to python --execute {}".format(test)
             result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
             strmessage = expected_message.decode("utf-8")
             strenderr = result.stderr.decode("utf-8")[-len(strmessage)::]

--- a/docs/test/global_eval_test.py
+++ b/docs/test/global_eval_test.py
@@ -10,8 +10,8 @@ var = uw.mesh.MeshVariable(mesh,2)
 
 # In[8]:
 
-var.data[:mesh.data_nodegId.shape[0],0] = mesh.data_nodegId[:,0]
-var.data[:mesh.data_nodegId.shape[0],1] = mesh.data_nodegId[:,0]
+var.data[:mesh.data_nodegId.shape[0],0] = mesh.data_nodegId[:]
+var.data[:mesh.data_nodegId.shape[0],1] = mesh.data_nodegId[:]
 uw.libUnderworld.StgFEM._FeVariable_SyncShadowValues( var._cself )
 
 # In[12]:

--- a/docs/test/shadow_particle_test.py
+++ b/docs/test/shadow_particle_test.py
@@ -20,7 +20,7 @@ randomNumber = swarm.add_variable('int',1)
 swarm.populate_using_layout(uw.swarm.layouts.PerCellSpaceFillerLayout(swarm,20))
 
 # init variables
-origOwningEl.data[:] = mesh.data_elgId[swarm.owningCell.data[:,0]] # global elementId where created
+origOwningEl.data[:] = mesh.data_elgId[swarm.owningCell.data[:]] # global elementId where created
 origCreatingProc.data[:] = uw.mpi.rank                               # rank where created
 origParticleIndex.data[:,0] = range(swarm.particleLocalCount)      # local index where created
 from random import randint

--- a/underworld/mesh/_mesh.py
+++ b/underworld/mesh/_mesh.py
@@ -141,7 +141,7 @@ class FeMesh(_stgermain.StgCompoundComponent, function.FunctionInput):
         """
         uw.libUnderworld.StgDomain.Mesh_GenerateElGlobalIdVar(self._cself)
         arr = uw.libUnderworld.StGermain.StgVariable_getAsNumpyArray(self._cself.eGlobalIdsVar)
-        return arr
+        return arr.flatten()
 
     @property
     def data_nodegId(self):
@@ -153,7 +153,7 @@ class FeMesh(_stgermain.StgCompoundComponent, function.FunctionInput):
         """
         uw.libUnderworld.StgDomain.Mesh_GenerateNodeGlobalIdVar(self._cself)
         arr = uw.libUnderworld.StGermain.StgVariable_getAsNumpyArray(self._cself.vGlobalIdsVar)
-        return arr
+        return arr.flatten()
 
     @property
     def data(self):

--- a/underworld/utils/_meshvariable_projection.py
+++ b/underworld/utils/_meshvariable_projection.py
@@ -159,7 +159,7 @@ class MeshVariable_Projection(_stgermain.StgCompoundComponent):
     >>> swarm.populate_using_layout(uw.swarm.layouts.PerCellSpaceFillerLayout(swarm,4))
     >>> projector = uw.utils.MeshVariable_Projection( U_submesh, swarm.owningCell, type=1 )
     >>> projector.solve()
-    >>> np.allclose(U_submesh.data, mesh.data_elgId)
+    >>> np.allclose(U_submesh.data[:,0], mesh.data_elgId)
     True
 
 


### PR DESCRIPTION
 * H5py v3 is more strict in allowed indexing array shapes. Updated our structures to accomodate.
* Tester uses `jupyter-nbconvert` which no longer defaults to Python. Update
  to explicitly select Python.