### PR TITLE
Updates for docker image generation:

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,13 +3,19 @@ CHANGES: Underworld2
 
 Release 2.11.0 []
 -----------------
-Changes
+Changes:
 * Enabled user defined Gauss integration swarms for all systems. 
 * Update docker base images: switch to ubuntu(20.04), update petsc(3.1.4) & mpich(3.3.2), other tweaks. 
 * Cleaner Python compile time configuration. 
 
-New:
+Docker image changes:
+* Update base image.
+* Updated to PETSc 3.15.1
+* Updated to MPICH 3.4.2
+* Removed petsc4py.
+* Switched `/opt` to ugo+rwx to allow users to install Python packages.
 
+New:
 * Mesh/MeshVariable/Swarm/SwarmVariable objects now support loading and saving
   of units information, as well as additional attributes. For usage examples, 
   see `docs/test/mesh_aux.py` and `docs/test/swarm_aux.py`. 

--- a/docs/development/docker/base/Dockerfile
+++ b/docs/development/docker/base/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:20.04 as base_runtime
-MAINTAINER https://github.com/underworldcode/
+LABEL maintainer="https://github.com/underworldcode/"
 ENV LANG=C.UTF-8
 ENV PYVER=3.8
 # Setup some things in anticipation of virtualenvs
@@ -8,6 +8,19 @@ ENV VIRTUAL_ENV=/opt/venv
 ENV PATH=${VIRTUAL_ENV}/bin:$PATH
 # The following ensures venv packages are available when using system python (such as from jupyter)
 ENV PYTHONPATH=${PYTHONPATH}:${VIRTUAL_ENV}/lib/python${PYVER}/site-packages
+
+# add joyvan user, volume mount and expose port 8888
+EXPOSE 8888
+ENV NB_USER jovyan
+ENV NB_WORK /home/$NB_USER
+RUN useradd -m -s /bin/bash -N $NB_USER -g users \
+&&  mkdir -p /$NB_WORK/workspace \
+&&  chown -R $NB_USER:users $NB_WORK
+VOLUME $NB_WORK/workspace
+
+# make virtualenv directory and set permissions 
+RUN mkdir ${VIRTUAL_ENV} \
+&&  chmod ugo+rwx ${VIRTUAL_ENV}
 
 # install runtime requirements
 RUN apt-get update -qq \
@@ -62,21 +75,9 @@ RUN apt-get update \
 &&  rm -rf /var/lib/apt/lists/* 
 RUN PYTHONPATH= /usr/bin/pip3 install -r /opt/requirements.txt
 
-# add tini, joyvan user, volume mount and expose port 8888
-EXPOSE 8888
-ENV NB_USER jovyan
-ENV NB_WORK /home/$NB_USER
-ADD https://github.com/krallin/tini/releases/download/v0.18.0/tini /tini
-RUN ipcluster nbextension enable \
-&&  chmod +x /tini \
-&&  useradd -m -s /bin/bash -N $NB_USER -g users \
-&&  mkdir -p /$NB_WORK/workspace \
-&&  chown -R $NB_USER:users $NB_WORK
-VOLUME $NB_WORK/workspace
-
 # jovyan user, finalise jupyter env
 USER $NB_USER
-RUN ipython profile create --parallel --profile=mpi \
-&&  echo "c.IPClusterEngines.engine_launcher_class = 'MPIEngineSetLauncher'" >> $NB_WORK/.ipython/profile_mpi/ipcluster_config.py
+# RUN ipython profile create --parallel --profile=mpi \
+# &&  echo "c.IPClusterEngines.engine_launcher_class = 'MPIEngineSetLauncher'" >> $NB_WORK/.ipython/profile_mpi/ipcluster_config.py
 WORKDIR $NB_WORK
 CMD ["jupyter", "notebook", "--no-browser", "--ip='0.0.0.0'"]

--- a/docs/development/docker/lavavu/Dockerfile
+++ b/docs/development/docker/lavavu/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:20.04 as base_runtime
-MAINTAINER https://github.com/underworldcode/
+LABEL maintainer="https://github.com/underworldcode/"
 ENV LANG=C.UTF-8
 ENV PYVER=3.8
 # Setup some things in anticipation of virtualenvs
@@ -8,6 +8,19 @@ ENV VIRTUAL_ENV=/opt/venv
 ENV PATH=${VIRTUAL_ENV}/bin:$PATH
 # The following ensures venv packages are available when using system python (such as from jupyter)
 ENV PYTHONPATH=${PYTHONPATH}:${VIRTUAL_ENV}/lib/python${PYVER}/site-packages
+
+# add joyvan user, volume mount and expose port 8888
+EXPOSE 8888
+ENV NB_USER jovyan
+ENV NB_WORK /home/$NB_USER
+RUN useradd -m -s /bin/bash -N $NB_USER -g users \
+&&  mkdir -p /$NB_WORK/workspace \
+&&  chown -R $NB_USER:users $NB_WORK
+VOLUME $NB_WORK/workspace
+
+# make virtualenv directory and set permissions 
+RUN mkdir ${VIRTUAL_ENV} \
+&&  chmod ugo+rwx ${VIRTUAL_ENV}
 
 # install runtime requirements
 RUN apt-get update -qq \
@@ -45,8 +58,8 @@ RUN apt-get update -qq
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
         build-essential \
         python3-setuptools \
-        libpython${PYVER}-dev \
-sudo apt-get install        libpng-dev \
+        libpython${PYVER}-dev \ 
+        libpng-dev \
         libjpeg-dev \
         libtiff-dev \
         mesa-utils \
@@ -63,6 +76,7 @@ sudo apt-get install        libpng-dev \
 
 # lavavu
 # create a virtualenv to put new python modules
+USER $NB_USER
 RUN /usr/bin/python3 -m virtualenv --system-site-packages --python=/usr/bin/python3 ${VIRTUAL_ENV}
 RUN LV_OSMESA=1 pip3 install --no-cache-dir --no-binary=lavavu lavavu
 
@@ -78,13 +92,6 @@ RUN apt-mark showmanual >/opt/installed.txt
 
 # Add user environment
 FROM minimal
-EXPOSE 8888
-ADD https://github.com/krallin/tini/releases/download/v0.18.0/tini /tini
-RUN chmod +x /tini
-ENV NB_USER jovyan
-RUN useradd -m -s /bin/bash -N jovyan
 USER $NB_USER
-ENV NB_WORK /home/$NB_USER
-VOLUME $NB_WORK/workspace
 WORKDIR $NB_WORK
 CMD ["jupyter", "notebook", "--no-browser", "--ip='0.0.0.0'"]

--- a/docs/development/docker/petsc/Dockerfile
+++ b/docs/development/docker/petsc/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:20.04 as base_runtime
-MAINTAINER https://github.com/underworldcode/
+LABEL maintainer="https://github.com/underworldcode/"
 ENV LANG=C.UTF-8
 ENV PYVER=3.8
 # Setup some things in anticipation of virtualenvs
@@ -8,6 +8,19 @@ ENV VIRTUAL_ENV=/opt/venv
 ENV PATH=${VIRTUAL_ENV}/bin:$PATH
 # The following ensures venv packages are available when using system python (such as from jupyter)
 ENV PYTHONPATH=${PYTHONPATH}:${VIRTUAL_ENV}/lib/python${PYVER}/site-packages
+
+# add joyvan user, volume mount and expose port 8888
+EXPOSE 8888
+ENV NB_USER jovyan
+ENV NB_WORK /home/$NB_USER
+RUN useradd -m -s /bin/bash -N $NB_USER -g users \
+&&  mkdir -p /$NB_WORK/workspace \
+&&  chown -R $NB_USER:users $NB_WORK
+VOLUME $NB_WORK/workspace
+
+# make virtualenv directory and set permissions 
+RUN mkdir ${VIRTUAL_ENV} \
+&&  chmod ugo+rwx ${VIRTUAL_ENV}
 
 # install runtime requirements
 RUN apt-get update -qq \
@@ -43,23 +56,26 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
         git
 # build mpi
 WORKDIR /tmp/mpich-build
-ARG MPICH_VERSION="3.3.2"
+ARG MPICH_VERSION="3.4.2"
 RUN wget http://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz 
 RUN  tar xvzf mpich-${MPICH_VERSION}.tar.gz 
 WORKDIR /tmp/mpich-build/mpich-${MPICH_VERSION}              
-ARG MPICH_CONFIGURE_OPTIONS="--prefix=/usr/local --enable-g=option=none --disable-debuginfo --enable-fast=O3,ndebug --without-timing --without-mpit-pvars"
+ARG MPICH_CONFIGURE_OPTIONS="--prefix=/usr/local --enable-g=option=none --disable-debuginfo --enable-fast=O3,ndebug --without-timing --without-mpit-pvars --with-device=ch3"
 ARG MPICH_MAKE_OPTIONS="-j8"
 RUN ./configure ${MPICH_CONFIGURE_OPTIONS} 
 RUN make ${MPICH_MAKE_OPTIONS}             
 RUN make install                           
 RUN ldconfig
-# create venv now for forthcoming python packages
-RUN /usr/bin/python3 -m virtualenv --system-site-packages --python=/usr/bin/python3 ${VIRTUAL_ENV}
 
+# create venv now for forthcoming python packages
+USER $NB_USER
+RUN /usr/bin/python3 -m virtualenv --system-site-packages --python=/usr/bin/python3 ${VIRTUAL_ENV}
 RUN pip3 install --no-cache-dir mpi4py
+
+USER root
 # build petsc
 WORKDIR /tmp/petsc-build
-ARG PETSC_VERSION="3.14.0"
+ARG PETSC_VERSION="3.15.1"
 RUN wget http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-${PETSC_VERSION}.tar.gz
 RUN tar zxf petsc-lite-${PETSC_VERSION}.tar.gz
 WORKDIR /tmp/petsc-build/petsc-${PETSC_VERSION}
@@ -85,8 +101,7 @@ RUN make PETSC_DIR=/tmp/petsc-build/petsc-${PETSC_VERSION} PETSC_ARCH=arch-linux
 RUN rm -fr /usr/local/share/petsc 
 # build petsc4py
 ENV PETSC_DIR=/usr/local
-ENV PETSC_ARCH=arch-linux-c-opt
-RUN pip3 install --no-cache-dir petsc4py
+USER $NB_USER
 RUN CC=h5pcc HDF5_MPI="ON" HDF5_DIR=${PETSC_DIR} pip3 install --no-cache-dir --no-binary=h5py git+https://github.com/h5py/h5py@master
 
 FROM base_runtime AS minimal
@@ -100,16 +115,6 @@ RUN apt-mark showmanual >/opt/installed.txt
 
 # Add user environment
 FROM minimal
-EXPOSE 8888
-RUN ipcluster nbextension enable
-ADD https://github.com/krallin/tini/releases/download/v0.18.0/tini /tini
-RUN chmod +x /tini
-ENV NB_USER jovyan
-RUN useradd -m -s /bin/bash -N jovyan
 USER $NB_USER
-ENV NB_WORK /home/$NB_USER
-RUN ipython profile create --parallel --profile=mpi && \
-    echo "c.IPClusterEngines.engine_launcher_class = 'MPIEngineSetLauncher'" >> $NB_WORK/.ipython/profile_mpi/ipcluster_config.py
-VOLUME $NB_WORK/workspace
 WORKDIR $NB_WORK
 CMD ["jupyter", "notebook", "--no-browser", "--ip='0.0.0.0'"]

--- a/docs/development/docker/stampede2/Dockerfile
+++ b/docs/development/docker/stampede2/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:bionic
-MAINTAINER https://github.com/underworldcode/
+LABEL maintainer="https://github.com/underworldcode/"
 
 RUN  mkdir /home1 /work /scratch /gpfs /corral-repl /corral-tacc /data
 

--- a/docs/development/docker/underworld2/Dockerfile
+++ b/docs/development/docker/underworld2/Dockerfile
@@ -2,8 +2,8 @@
 # Typically:
 #    $  docker build -f docs/development/docker/underworld2/Dockerfile .
 
-FROM underworldcode/base@sha256:f194ce40ea602305141a6a95fad640c90dd7ae5fae7532cd164dc566ec465edb as base_runtime
-MAINTAINER https://github.com/underworldcode/
+FROM underworldcode/base@sha256:27198726bedbe747889d4db096d5e15bf0c7cec5c9dc07c483b1d02acdfff543 as base_runtime
+LABEL maintainer="https://github.com/underworldcode/"
 # install runtime requirements
 USER root
 ENV PYVER=3.8
@@ -22,6 +22,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
         libxml2-dev
 RUN PYTHONPATH= /usr/bin/pip3 install --no-cache-dir setuptools scons 
 # setup further virtualenv to avoid double copying back previous packages (h5py,mpi4py,etc)
+USER $NB_USER
 RUN /usr/bin/python3 -m virtualenv --system-site-packages --python=/usr/bin/python3 ${VIRTUAL_ENV}
 WORKDIR /tmp
 COPY --chown=jovyan:users . /tmp/underworld2
@@ -47,7 +48,7 @@ COPY --chown=jovyan:users ./docs/test       $NB_WORK/Underworld/test
 COPY --from=build_base --chown=jovyan:users /tmp/UWGeodynamics/docs/examples   $NB_WORK/UWGeodynamics/examples
 COPY --from=build_base --chown=jovyan:users /tmp/UWGeodynamics/docs/tutorials  $NB_WORK/UWGeodynamics/tutorials
 COPY --from=build_base --chown=jovyan:users /tmp/UWGeodynamics/docs/benchmarks $NB_WORK/UWGeodynamics/benchmarks
-RUN  chown jovyan:users /home/jovyan/workspace /home/jovyan/UWGeodynamics
+RUN chown jovyan:users /home/jovyan/workspace /home/jovyan/UWGeodynamics
 RUN jupyter serverextension enable --sys-prefix jupyter_server_proxy
 USER $NB_USER
 WORKDIR $NB_WORK


### PR DESCRIPTION
* Switch deprecated `MAINTAINER` tag for new `LABEL` construct.
* Set `/opt` to ugo+rwx to allow users to install new pip packages.
* Remove `tini` which no longer appears to be required (and wasn't
  being used previously in any case).
* Remove extras for notebook MPI usage, as this wasn't being used
  and is easy to reinstall.
* Update UW image to point to newest base file image.