### PR TITLE
gh-action to build "development" docker after push

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -24,4 +24,4 @@ jobs:
           context: .
           file: ./docs/development/docker/underworld2/Dockerfile
           push: true
-          tags: "underworldcode/underworld2:dev"    
+          tags: "underworldcode/underworld2:${GITHUB_REF#refs/heads/}" 

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -24,4 +24,4 @@ jobs:
           context: .
           file: ./docs/development/docker/underworld2/Dockerfile
           push: true
-          tags: underworldcode/underworld2:${GITHUB_REF#refs/*/}       
+          tags: underworldcode/underworld2:${GITHUB_REF}       

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -24,4 +24,4 @@ jobs:
           context: .
           file: ./docs/development/docker/underworld2/Dockerfile
           push: true
-          tags: "underworldcode/underworld2:development"    
+          tags: "underworldcode/underworld2:dev"    

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -24,4 +24,4 @@ jobs:
           context: .
           file: ./docs/development/docker/underworld2/Dockerfile
           push: true
-          tags: "underworldcode/underworld2:${GITHUB_REF##*/}"    
+          tags: "underworldcode/underworld2:development"    

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -14,7 +14,7 @@ jobs:
         
       # Use bash to 
       - name: Extract Branch name
-        run: run: echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+        run: echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
 
       - name: Login to DockerHub
         uses: docker/login-action@v1 

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -11,6 +11,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        
+      # Use bash to 
+      - name: Extract Branch name
+        run: run: echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
 
       - name: Login to DockerHub
         uses: docker/login-action@v1 
@@ -24,4 +28,4 @@ jobs:
           context: .
           file: ./docs/development/docker/underworld2/Dockerfile
           push: false
-          tags: ${GITHUB_REF#refs/heads/}
+          tags: underworldcode/underworld2:${{ env.BRANCH }}

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -24,4 +24,4 @@ jobs:
           context: .
           file: ./docs/development/docker/underworld2/Dockerfile
           push: true
-          tags: "underworldcode/underworld2:${GITHUB_REF#refs/heads/}" 
+          tags: underworldcode/underworld2:${GITHUB_REF#refs/heads/}

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -24,4 +24,4 @@ jobs:
           context: .
           file: ./docs/development/docker/underworld2/Dockerfile
           push: true
-          tags: underworldcode/underworld2:${GITHUB_REF##*/}       
+          tags: underworldcode/underworld2:${GITHUB_REF#refs/*/}       

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -1,0 +1,27 @@
+name: docker image build and push to dockerhub
+
+on:
+  push:
+    branches:
+      - 'development'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./docs/development/docker/underworld2/Dockerfile
+          push: true
+          tags: underworldcode/underworld2:${GITHUB_REF##*/}       

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -24,4 +24,4 @@ jobs:
           context: .
           file: ./docs/development/docker/underworld2/Dockerfile
           push: true
-          tags: underworldcode/underworld2:${GITHUB_REF}       
+          tags: "underworldcode/underworld2:${GITHUB_REF##*/}"    

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -24,4 +24,4 @@ jobs:
           context: .
           file: ./docs/development/docker/underworld2/Dockerfile
           push: false
-          tags: julesg/underworld2-${GITHUB_REF#refs/heads/}
+          tags: ${GITHUB_REF#refs/heads/}

--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -23,5 +23,5 @@ jobs:
         with:
           context: .
           file: ./docs/development/docker/underworld2/Dockerfile
-          push: true
-          tags: underworldcode/underworld2:${GITHUB_REF#refs/heads/}
+          push: false
+          tags: julesg/underworld2-${GITHUB_REF#refs/heads/}


### PR DESCRIPTION
First cut at gh actions. This should build the docker and push it to docker hub on development only.

Future ideas:
* add workflow to run unit tests.
* add workflow to run large test on HPC/kaiju.
* Record meta data from above runs to automatically create performance graphs.# PR Checklist