### PR TITLE
MPICH 3.4.3 and pkg-config REQUIRED

### DIFF
--- a/docs/development/docker/petsc/Dockerfile
+++ b/docs/development/docker/petsc/Dockerfile
@@ -57,11 +57,13 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
         git
 # build mpi
 WORKDIR /tmp/mpich-build
-ARG MPICH_VERSION="4.0.2"
+ARG MPICH_VERSION="3.4.3"
 RUN wget http://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz 
 RUN  tar xvzf mpich-${MPICH_VERSION}.tar.gz 
 WORKDIR /tmp/mpich-build/mpich-${MPICH_VERSION}              
-ARG MPICH_CONFIGURE_OPTIONS="--prefix=/usr/local --enable-g=option=none --disable-debuginfo --enable-fast=O3,ndebug --without-timing --without-mpit-pvars --with-device=ch3 FFLAGS=-fallow-argument-mismatch FCFLAGS=-fallow-argument-mismatch"
+# take from https://github.com/PawseySC/pawsey-containers/blob/master/mpi/mpich-base/Dockerfile
+ARG MPICH_CONFIGURE_OPTIONS="--enable-fast=all,O3 --prefix=/usr/local --with-device=ch4:ofi FFLAGS=-fallow-argument-mismatch FCFLAGS=-fallow-argument-mismatch"
+#ARG MPICH_CONFIGURE_OPTIONS="--prefix=/usr/local --enable-g=option=none --disable-debuginfo --enable-fast=O3,ndebug --without-timing --without-mpit-pvars --with-device=ch3 FFLAGS=-fallow-argument-mismatch FCFLAGS=-fallow-argument-mismatch"
 ARG MPICH_MAKE_OPTIONS="-j8"
 RUN ./configure ${MPICH_CONFIGURE_OPTIONS} 
 RUN make ${MPICH_MAKE_OPTIONS}             

--- a/underworld/libUnderworld/CMakeLists.txt
+++ b/underworld/libUnderworld/CMakeLists.txt
@@ -5,7 +5,7 @@ set(Python_FIND_VIRTUALENV ONLY)
 cmake_policy(SET CMP0078 OLD)
 
 project(Underworld)
-find_package(PkgConfig)
+find_package(PkgConfig REQUIRED)
 find_package(LibXml2 REQUIRED)
 find_package(MPI REQUIRED)
 


### PR DESCRIPTION
* MPICH 3.4.3 for singularity compatibility - setonix style
* Force cmake to fail early if no pkg-config found
