### PR TITLE
fix restart bug in coupling with badlands in uwg

### DIFF
--- a/src/underworld/UWGeodynamics/_model.py
+++ b/src/underworld/UWGeodynamics/_model.py
@@ -2958,11 +2958,14 @@ class _RestartFunction(object):
         XML = badlands_model.XML
         resolution = badlands_model.resolution
         checkpoint_interval = badlands_model.checkpoint_interval
+        aspectRatio2d = badlands_model.aspectRatio2d
+        surfElevation = badlands_model.surfElevation
 
         Model.surfaceProcesses = surfaceProcesses.Badlands(
             airIndex, sedimentIndex,
             XML, resolution,
             checkpoint_interval,
+            surfElevation=surfElevation,aspectRatio2d=aspectRatio2d,
             restartFolder=restartFolder,
             restartStep=restartStep)
 


### PR DESCRIPTION
Fix the bug in the restart process when coupling with Badlands. See Issue #731

Models for testing can be found in the [uwg-coupling-test repository](https://github.com/underworld-community/uwg-coupling-test/tree/main/TestRestart_TopoRelax).

The issue arises because the aspectRatio parameter is not being passed correctly to Badlands for recreating the initial mesh. If users set aspectratio to a value other than the default (1.0), it causes a mismatch between the size of the reinitialised mesh and the calculated mesh in Badlands.